### PR TITLE
Configurable deploy excludes

### DIFF
--- a/dotorg-plugin-deploy/Dockerfile
+++ b/dotorg-plugin-deploy/Dockerfile
@@ -12,8 +12,8 @@ LABEL repository="http://github.com/helen/actions-wordpress"
 RUN apt-get update \
 	&& apt-get install -y subversion rsync git \
 	&& apt-get clean -y \
-	&& rm -rf /var/lib/apt/lists/*
-	&& git config --global user.email "10upbot+github@10up.com"
+	&& rm -rf /var/lib/apt/lists/* \
+	&& git config --global user.email "10upbot+github@10up.com" \
 	&& git config --global user.name "10upbot on GitHub"
 
 COPY entrypoint.sh /entrypoint.sh

--- a/dotorg-plugin-deploy/Dockerfile
+++ b/dotorg-plugin-deploy/Dockerfile
@@ -10,7 +10,7 @@ LABEL version="1.0.0"
 LABEL repository="http://github.com/helen/actions-wordpress"
 
 RUN apt-get update \
-	&& apt-get install -y subversion rsync \
+	&& apt-get install -y subversion rsync git \
 	&& apt-get clean -y \
 	&& rm -rf /var/lib/apt/lists/*
 

--- a/dotorg-plugin-deploy/Dockerfile
+++ b/dotorg-plugin-deploy/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update \
 	&& apt-get install -y subversion rsync git \
 	&& apt-get clean -y \
 	&& rm -rf /var/lib/apt/lists/*
+	&& git config --global user.email "10upbot+github@10up.com"
+	&& git config --global user.name "10upbot on GitHub"
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/dotorg-plugin-deploy/README.md
+++ b/dotorg-plugin-deploy/README.md
@@ -7,11 +7,12 @@ This Action commits the contents of your Git tag to the WordPress.org plugin rep
 ### Required secrets
 * `SVN_USERNAME`
 * `SVN_PASSWORD`
+* `GITHUB_TOKEN` - you do not need to generate one but you do have to explicitly make it available to the Action
 
 Secrets can be set while editing your workflow or in the repository settings. They cannot be viewed once stored. [GitHub secrets documentation](https://developer.github.com/actions/creating-workflows/storing-secrets/)
 
 ### Optional environment variables
-* `SLUG` - defaults to the respository name, customizable in case your WordPress repository has a different slug
+* `SLUG` - defaults to the respository name, customizable in case your WordPress repository has a different slug. This should be a very rare case as WordPress assumes that the directory and initial plugin file have the same slug.
 * `VERSION` - defaults to the tag name; do not recommend setting this except for testing purposes
 * `ASSETS_DIR` - defaults to `.wordpress-org`, customizable for other locations of WordPress.org plugin repository-specific assets that belong in the top-level `assets` directory (the one on the same level as `trunk`)
 
@@ -31,7 +32,7 @@ action "tag" {
 action "WordPress Plugin Deploy" {
   needs = ["tag"]
   uses = "10up/actions-wordpress/dotorg-plugin-deploy@master"
-  secrets = ["SVN_PASSWORD", "SVN_USERNAME"]
+  secrets = ["SVN_USERNAME", "SVN_PASSWORD", "GITHUB_TOKEN"]
   env = {
     SLUG = "my-super-cool-plugin"
   }

--- a/dotorg-plugin-deploy/entrypoint.sh
+++ b/dotorg-plugin-deploy/entrypoint.sh
@@ -60,6 +60,9 @@ cd "$GITHUB_WORKSPACE"
 TMP_DIR="/github/archivetmp"
 mkdir "$TMP_DIR"
 
+git config --global user.email "10upbot+github@10up.com"
+git config --global user.name "10upbot on GitHub"
+
 # If there's no .gitattributes file, write a default one into place
 if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]; then
 	cat > "$GITHUB_WORKSPACE/.gitattributes" <<-EOL

--- a/dotorg-plugin-deploy/entrypoint.sh
+++ b/dotorg-plugin-deploy/entrypoint.sh
@@ -37,6 +37,22 @@ if [[ -z "$ASSETS_DIR" ]]; then
 fi
 echo "ℹ︎ ASSETS_DIR is $ASSETS_DIR"
 
+# If there's no .gitattributes file, write a default one into place
+if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]
+	cat > "$GITHUB_WORKSPACE/.gitattributes" <<-EOL
+	/$ASSETS_DIR export-ignore
+	/.gitattributes export-ignore
+	/.gitignore export-ignore
+	/.github export-ignore
+	EOL
+
+	# Ensure we are in the $GITHUB_WORKSPACE directory, just in case
+	# The .gitattributes file has to be committed to be used
+	# Just don't push it to the origin repo :)
+	cd $GITHUB_WORKSPACE
+	git add .gitattributes && git commit -m "Add .gitattributes file" > /dev/null
+fi
+
 SVN_URL="http://plugins.svn.wordpress.org/${SLUG}/"
 SVN_DIR="/github/svn-${SLUG}"
 
@@ -50,16 +66,6 @@ svn update --set-depth infinity trunk
 
 echo "➤ Copying files..."
 
-# If there's no .gitattributes file, write a default one into place
-if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]
-	cat > "$GITHUB_WORKSPACE/.gitattributes" <<-EOL
-	/$ASSETS_DIR export-ignore
-	/.git export-ignore
-	/.gitattributes export-ignore
-	/.gitignore export-ignore
-	/.github export-ignore
-	EOL
-fi
 
 # Copy from current branch to /trunk, excluding dotorg assets
 # The --delete flag will delete anything in destination that no longer exists in source

--- a/dotorg-plugin-deploy/entrypoint.sh
+++ b/dotorg-plugin-deploy/entrypoint.sh
@@ -66,9 +66,13 @@ git config --global user.name "10upbot on GitHub"
 git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
 git fetch --all --tags --prune
+jobs -l
+sleep 10
 wait $!
 git checkout "$VERSION"
+jobs -l
 wait $!
+sleep 10
 
 # If there's no .gitattributes file, write a default one into place
 if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]; then

--- a/dotorg-plugin-deploy/entrypoint.sh
+++ b/dotorg-plugin-deploy/entrypoint.sh
@@ -60,20 +60,6 @@ cd "$GITHUB_WORKSPACE"
 TMP_DIR="/github/archivetmp"
 mkdir "$TMP_DIR"
 
-git config --global user.email "10upbot+github@10up.com"
-git config --global user.name "10upbot on GitHub"
-
-git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-
-git fetch --all --tags --prune
-jobs -l
-sleep 10
-wait $!
-git checkout "$VERSION"
-jobs -l
-wait $!
-sleep 10
-
 # If there's no .gitattributes file, write a default one into place
 if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]; then
 	cat > "$GITHUB_WORKSPACE/.gitattributes" <<-EOL

--- a/dotorg-plugin-deploy/entrypoint.sh
+++ b/dotorg-plugin-deploy/entrypoint.sh
@@ -38,7 +38,7 @@ fi
 echo "ℹ︎ ASSETS_DIR is $ASSETS_DIR"
 
 # If there's no .gitattributes file, write a default one into place
-if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]
+if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]; then
 	cat > "$GITHUB_WORKSPACE/.gitattributes" <<-EOL
 	/$ASSETS_DIR export-ignore
 	/.gitattributes export-ignore

--- a/dotorg-plugin-deploy/entrypoint.sh
+++ b/dotorg-plugin-deploy/entrypoint.sh
@@ -65,8 +65,8 @@ git config --global user.name "10upbot on GitHub"
 
 git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
-git fetch --all --tags --prune
-git checkout "$VERSION"
+git fetch --all --tags --prune < /dev/null
+git checkout "$VERSION" < /dev/null
 
 # If there's no .gitattributes file, write a default one into place
 if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]; then

--- a/dotorg-plugin-deploy/entrypoint.sh
+++ b/dotorg-plugin-deploy/entrypoint.sh
@@ -63,6 +63,8 @@ mkdir "$TMP_DIR"
 git config --global user.email "10upbot+github@10up.com"
 git config --global user.name "10upbot on GitHub"
 
+git status
+
 # If there's no .gitattributes file, write a default one into place
 if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]; then
 	cat > "$GITHUB_WORKSPACE/.gitattributes" <<-EOL

--- a/dotorg-plugin-deploy/entrypoint.sh
+++ b/dotorg-plugin-deploy/entrypoint.sh
@@ -65,8 +65,9 @@ git config --global user.name "10upbot on GitHub"
 
 git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
-git fetch --all --tags --prune < /dev/null
-git checkout "$VERSION" < /dev/null
+git fetch --all --tags --prune
+git checkout "$VERSION"
+wait $!
 
 # If there's no .gitattributes file, write a default one into place
 if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]; then

--- a/dotorg-plugin-deploy/entrypoint.sh
+++ b/dotorg-plugin-deploy/entrypoint.sh
@@ -63,8 +63,6 @@ mkdir "$TMP_DIR"
 git config --global user.email "10upbot+github@10up.com"
 git config --global user.name "10upbot on GitHub"
 
-git status
-
 # If there's no .gitattributes file, write a default one into place
 if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]; then
 	cat > "$GITHUB_WORKSPACE/.gitattributes" <<-EOL
@@ -83,6 +81,8 @@ fi
 # This will exclude everything in the .gitattributes file with the export-ignore flag
 git archive HEAD | tar x --directory="$TMP_DIR"
 
+cd "$SVN_DIR"
+
 # Copy from clean copy to /trunk, excluding dotorg assets
 # The --delete flag will delete anything in destination that no longer exists in source
 rsync -r "$TMP_DIR/" trunk/ --delete
@@ -94,7 +94,6 @@ rsync -r "$GITHUB_WORKSPACE/$ASSETS_DIR/" assets/ --delete
 # The force flag ensures we recurse into subdirectories even if they are already added
 # Suppress stdout in favor of svn status later for readability
 echo "➤ Preparing files..."
-cd "$SVN_DIR"
 svn add . --force > /dev/null
 
 # SVN delete all deleted files

--- a/dotorg-plugin-deploy/entrypoint.sh
+++ b/dotorg-plugin-deploy/entrypoint.sh
@@ -50,6 +50,17 @@ svn update --set-depth infinity trunk
 
 echo "➤ Copying files..."
 
+# If there's no .gitattributes file, write a default one into place
+if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]
+	cat > "$GITHUB_WORKSPACE/.gitattributes" <<-EOL
+	/$ASSETS_DIR export-ignore
+	/.git export-ignore
+	/.gitattributes export-ignore
+	/.gitignore export-ignore
+	/.github export-ignore
+	EOL
+fi
+
 # Copy from current branch to /trunk, excluding dotorg assets
 # The --delete flag will delete anything in destination that no longer exists in source
 rsync -r --exclude "/$ASSETS_DIR/" --exclude ".git/" --exclude ".github/" "$GITHUB_WORKSPACE/" trunk/ --delete

--- a/dotorg-plugin-deploy/entrypoint.sh
+++ b/dotorg-plugin-deploy/entrypoint.sh
@@ -54,7 +54,7 @@ svn update --set-depth infinity assets
 svn update --set-depth infinity trunk
 
 echo "➤ Copying files..."
-cd $GITHUB_WORKSPACE
+cd "$GITHUB_WORKSPACE"
 
 # "Export" a cleaned copy to a temp directory
 TMP_DIR="/github/archivetmp"
@@ -63,10 +63,10 @@ mkdir "$TMP_DIR"
 git config --global user.email "10upbot+github@10up.com"
 git config --global user.name "10upbot on GitHub"
 
-git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
-git fetch origin $VERSION
-git checkout $VERSION
+git fetch origin "$VERSION"
+git checkout "$VERSION"
 
 # If there's no .gitattributes file, write a default one into place
 if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]; then

--- a/dotorg-plugin-deploy/entrypoint.sh
+++ b/dotorg-plugin-deploy/entrypoint.sh
@@ -65,7 +65,7 @@ git config --global user.name "10upbot on GitHub"
 
 git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
-git fetch origin "$VERSION"
+git fetch --all --tags --prune
 git checkout "$VERSION"
 
 # If there's no .gitattributes file, write a default one into place

--- a/dotorg-plugin-deploy/entrypoint.sh
+++ b/dotorg-plugin-deploy/entrypoint.sh
@@ -66,10 +66,16 @@ svn update --set-depth infinity trunk
 
 echo "➤ Copying files..."
 
+# "Export" a cleaned copy to a temp directory
+TMP_DIR="/github/archivetmp"
+mkdir "$TMP_DIR"
 
-# Copy from current branch to /trunk, excluding dotorg assets
+# This will exclude everything in the .gitattributes file with the export-ignore flag
+git archive HEAD | tar x --directory="$TMP_DIR"
+
+# Copy from clean copy to /trunk, excluding dotorg assets
 # The --delete flag will delete anything in destination that no longer exists in source
-rsync -r --exclude "/$ASSETS_DIR/" --exclude ".git/" --exclude ".github/" "$GITHUB_WORKSPACE/" trunk/ --delete
+rsync -r "$TMP_DIR/" trunk/ --delete
 
 # Copy dotorg assets to /assets
 rsync -r "$GITHUB_WORKSPACE/$ASSETS_DIR/" assets/ --delete

--- a/dotorg-plugin-deploy/entrypoint.sh
+++ b/dotorg-plugin-deploy/entrypoint.sh
@@ -6,6 +6,8 @@
 # it does not exit with a 0, and I only care about the final exit.
 set -eo
 
+git config --global user.email "10upbot+github@10up.com" && git config --global user.name "10upbot on GitHub"
+
 # Ensure SVN username and password are set
 # IMPORTANT: while secrets are encrypted and not viewable in the GitHub UI,
 # they are by necessity provided as plaintext in the context of the Action,

--- a/dotorg-plugin-deploy/entrypoint.sh
+++ b/dotorg-plugin-deploy/entrypoint.sh
@@ -50,7 +50,7 @@ if [[ ! -e "$GITHUB_WORKSPACE/.gitattributes" ]]; then
 	# The .gitattributes file has to be committed to be used
 	# Just don't push it to the origin repo :)
 	cd $GITHUB_WORKSPACE
-	git add .gitattributes && git commit -m "Add .gitattributes file" > /dev/null
+	git add .gitattributes && git commit -m "Add .gitattributes file"
 fi
 
 SVN_URL="http://plugins.svn.wordpress.org/${SLUG}/"

--- a/dotorg-plugin-deploy/entrypoint.sh
+++ b/dotorg-plugin-deploy/entrypoint.sh
@@ -66,6 +66,7 @@ git config --global user.name "10upbot on GitHub"
 git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
 git fetch --all --tags --prune
+wait $!
 git checkout "$VERSION"
 wait $!
 


### PR DESCRIPTION
Uses `git archive` to respect a `.gitattributes` file with `export-ignore` directives

Default `.gitattributes` file is provided/written in place - I believe the current `$GITHUB_WORKSPACE` is a checkout; however, I don't know that for sure so I'll be testing this shortly to check. If it's not there are two options:

1. Do an actual checkout of the tag (I think the ref is provided in env variables during the Action) before proceeding.
2. Parse `.gitattributes` into a file formatted for `rsync --exclude-from`. I don't know if this is a _good_ idea, but it's an idea.

/cc @johnbillion

Fixes #1 