### PR TITLE
Detect stable tag and copy readme.txt changes there

### DIFF
--- a/dotorg-plugin-asset-update/README.md
+++ b/dotorg-plugin-asset-update/README.md
@@ -1,6 +1,8 @@
 # WordPress.org Plugin Assets Update
 
-This Action commits any `readme.txt` and WordPress.org-specific `assets` changes in your specified stable branch (typically `master`) to the WordPress.org plugin repository if no other changes have been made. This is useful for updating things like screenshots or `Tested up to` separately from functional changes provided your Git branching methodology avoids changing anything else in the specified branch between functional releases.
+This Action commits any `readme.txt` and WordPress.org-specific `assets` changes in your specified stable branch (typically `master`) to the WordPress.org plugin repository if no other changes have been made since the last deployment to WordPress.org. This is useful for updating things like screenshots or `Tested up to` separately from functional changes, provided your Git branching methodology avoids changing anything else in the specified branch between functional releases.
+
+**Important note:** If your development process leads to a situation where `master` (or other specified branch) only contains changes to `readme.txt` or `assets` since the last sync to the plugin directory and those changes are in preparation for the next release, those changes will go live and potentially be misleading to users. Usage of this Action assumes a fairly traditional Git methodology that involves merging all changes to `master` when functional changes are ready and that this seemingly unlikely situation will therefore not happen in your repo; there are no safeguards against syncing changes based on readme/asset content, as that cannot be predicted.
 
 ## Configuration
 

--- a/dotorg-plugin-asset-update/entrypoint.sh
+++ b/dotorg-plugin-asset-update/entrypoint.sh
@@ -72,10 +72,10 @@ cd "$SVN_DIR"
 
 # Copy from clean copy to /trunk, excluding dotorg assets
 # The --delete flag will delete anything in destination that no longer exists in source
-rsync -r "$TMP_DIR/" trunk/ --delete
+rsync -rc "$TMP_DIR/" trunk/ --delete
 
 # Copy dotorg assets to /assets
-rsync -r "$GITHUB_WORKSPACE/$ASSETS_DIR/" assets/ --delete
+rsync -rc "$GITHUB_WORKSPACE/$ASSETS_DIR/" assets/ --delete
 
 echo "➤ Preparing files..."
 
@@ -106,7 +106,7 @@ else
 		svn update --set-depth infinity "tags/$STABLE_TAG"
 
 		# Not doing the copying in SVN for the sake of easy history
-		rsync "$TMP_DIR/readme.txt" "tags/$STABLE_TAG/"
+		rsync -c "$TMP_DIR/readme.txt" "tags/$STABLE_TAG/"
 	else
 		echo "ℹ︎ Tag $STABLE_TAG not found"
 	fi

--- a/dotorg-plugin-asset-update/entrypoint.sh
+++ b/dotorg-plugin-asset-update/entrypoint.sh
@@ -100,9 +100,7 @@ if [ -z "$STABLE_TAG" ]; then
 else
 	echo "ℹ︎ STABLE_TAG is $STABLE_TAG"
 
-	svn info "^/$SLUG/tags/$STABLE_TAG" > /dev/null
-
-	if [ $? == "0" ]; then
+	if svn info "^/$SLUG/tags/$STABLE_TAG" > /dev/null 2>&1; then
 		svn update --set-depth infinity "tags/$STABLE_TAG"
 
 		# Not doing the copying in SVN for the sake of easy history

--- a/dotorg-plugin-asset-update/entrypoint.sh
+++ b/dotorg-plugin-asset-update/entrypoint.sh
@@ -109,16 +109,15 @@ else
 	echo "ℹ︎ STABLE_TAG is $STABLE_TAG"
 
 	svn info "^/$SLUG/tags/$STABLE_TAG" > /dev/null
-	HAS_STABLE=$?
-fi
 
-if [ "$HAS_STABLE" == "0" ]; then
-	svn update --set-depth infinity "tags/$STABLE_TAG"
+	if [ $? == "0" ]; then
+		svn update --set-depth infinity "tags/$STABLE_TAG"
 
-	# Not doing the copying in SVN for the sake of easy history
-	rsync "$TMP_DIR/readme.txt" "tags/$STABLE_TAG/"
-else
-	echo "ℹ︎ Tag $STABLE_TAG not found"
+		# Not doing the copying in SVN for the sake of easy history
+		rsync "$TMP_DIR/readme.txt" "tags/$STABLE_TAG/"
+	else
+		echo "ℹ︎ Tag $STABLE_TAG not found"
+	fi
 fi
 
 echo "➤ Committing files..."


### PR DESCRIPTION
### Description of the Change

Parse stable tag out of readme.txt and copy readme.txt changes to said tag in SVN if it exists, because the .org repo displays info from the stable tag's readme.

### Alternate Designs

See #11 which did not take the stable tag into account.

### Benefits

Actually make #11 valuable.

### Possible Drawbacks

If somebody's Git dev process somehow involves pushing a change for a new version to master that's only readme/assets before any other changes are pushed, it will deploy it. I have no idea what kind of process would cause that, but it's technically possible that somebody would update a readme or an asset before committing functional changes.

### Verification Process

Tested pieces locally, ran Shellcheck, running tests against an actual repo now.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

#11 