### PR TITLE
Add `-c` flag to rsync for more robust change detection

### DIFF
--- a/dotorg-plugin-deploy/entrypoint.sh
+++ b/dotorg-plugin-deploy/entrypoint.sh
@@ -85,10 +85,10 @@ cd "$SVN_DIR"
 
 # Copy from clean copy to /trunk, excluding dotorg assets
 # The --delete flag will delete anything in destination that no longer exists in source
-rsync -r "$TMP_DIR/" trunk/ --delete
+rsync -rc "$TMP_DIR/" trunk/ --delete
 
 # Copy dotorg assets to /assets
-rsync -r "$GITHUB_WORKSPACE/$ASSETS_DIR/" assets/ --delete
+rsync -rc "$GITHUB_WORKSPACE/$ASSETS_DIR/" assets/ --delete
 
 # Add everything and commit to SVN
 # The force flag ensures we recurse into subdirectories even if they are already added


### PR DESCRIPTION
Sometimes the only change being made to a file is to a version number which often ends up with the same number of characters. Despite rsync's claim to check file mod time, it's not good enough and would sometimes miss changed files. Reproduced in #12.

Fixes #10