### PR TITLE
add the possibility to use a README.md instead of a readme.txt file

### DIFF
--- a/dotorg-plugin-asset-update/README.md
+++ b/dotorg-plugin-asset-update/README.md
@@ -17,6 +17,7 @@ Secrets can be set while editing your workflow or in the repository settings. Th
 ### Optional environment variables
 * `SLUG` - defaults to the respository name, customizable in case your WordPress repository has a different slug. This should be a very rare case as WordPress assumes that the directory and initial plugin file have the same slug.
 * `ASSETS_DIR` - defaults to `.wordpress-org`, customizable for other locations of WordPress.org plugin repository-specific assets that belong in the top-level `assets` directory (the one on the same level as `trunk`)
+* `README_NAME` - defaults to `readme.txt`, customizable this value, if you are using a `README.md` file for this plugin which should be used for the WordPress plugin directory as well.
 
 ### Known issues
 * It would be more efficient to additionally use the `paths` filter for the `push` action to reduce the number of runs. So far in testing it is possible to limit it to pushes that include readme/asset files as specified, but not ones that *only* include those files. The Action itself still needs to run as written because it compares the totality of changes in the branch against what's in SVN and not just the contents of the current push.

--- a/dotorg-plugin-asset-update/entrypoint.sh
+++ b/dotorg-plugin-asset-update/entrypoint.sh
@@ -29,6 +29,11 @@ if [[ -z "$ASSETS_DIR" ]]; then
 fi
 echo "ℹ︎ ASSETS_DIR is $ASSETS_DIR"
 
+if [[ -z "$README_NAME" ]]; then
+	README_NAME="$README_NAME"
+fi
+echo "ℹ︎ README_NAME is $README_NAME"
+
 SVN_URL="http://plugins.svn.wordpress.org/${SLUG}/"
 SVN_DIR="/github/svn-${SLUG}"
 
@@ -87,17 +92,17 @@ if [[ -z $(svn stat) ]]; then
 # Check if there is more than just the readme.txt modified in trunk
 # The leading whitespace in the pattern is important
 # so it doesn't match potential readme.txt in subdirectories!
-elif svn stat trunk | grep -qvi ' trunk/readme.txt$'; then
+elif svn stat trunk | grep -qvi " trunk/$README_NAME$"; then
 	echo "🛑 Other files have been modified; changes not deployed"
 	exit 1
 fi
 
 # Readme also has to be updated in the .org tag
 echo "➤ Preparing stable tag..."
-STABLE_TAG=$(grep -m 1 "^Stable tag:" "$TMP_DIR/readme.txt" | tr -d '\r\n' | awk -F ' ' '{print $NF}')
+STABLE_TAG=$(grep -m 1 "^Stable tag:" "$TMP_DIR/$README_NAME" | tr -d '\r\n' | awk -F ' ' '{print $NF}')
 
 if [ -z "$STABLE_TAG" ]; then
-    echo "ℹ︎ Could not get stable tag from readme.txt";
+    echo "ℹ︎ Could not get stable tag from $README_NAME";
 	HAS_STABLE=1
 else
 	echo "ℹ︎ STABLE_TAG is $STABLE_TAG"
@@ -106,7 +111,7 @@ else
 		svn update --set-depth infinity "tags/$STABLE_TAG"
 
 		# Not doing the copying in SVN for the sake of easy history
-		rsync -c "$TMP_DIR/readme.txt" "tags/$STABLE_TAG/"
+		rsync -c "$TMP_DIR/$README_NAME" "tags/$STABLE_TAG/"
 	else
 		echo "ℹ︎ Tag $STABLE_TAG not found"
 	fi


### PR DESCRIPTION
### Description of the Change

Add an environment variable `README_NAME` to enable users to us a `README.md` instead of a `readme.txt` file.

### Alternate Designs

Automatically detect the readme's file name.

### Benefits

As many WordPress plugins hosted on GitHub are nowadays using a `README.md` file, this change enables users to use the assted action on those plugins as well.

### Possible Drawbacks

n/a

### Verification Process

I ran the bash script locally and [on one of my plugins](https://github.com/2ndkauboy/SyntaxHighlighter-Evolved-SASS-Brush/runs/199067761) which uses a `README.md` file.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

n/a